### PR TITLE
Add CentOS support to github-authorized-keys

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -25,9 +25,7 @@ else
 fi
 
 # Create secret file
-/bin/mkdir /etc/secrets
-/bin/chmod 700 /etc/secrets
-cat << EOF > /etc/secrets/github-authorized-keys
+cat << EOF > /etc/defaults/github-authorized-keys
 GITHUB_API_TOKEN=${github_api_token}
 GITHUB_ORGANIZATION=${github_organization}
 GITHUB_TEAM=${github_team}

--- a/user_data.sh
+++ b/user_data.sh
@@ -7,14 +7,14 @@
 if  [ -f "/etc/redhat-release" ]; then
 
   echo '%wheel	ALL=(ALL)	NOPASSWD: ALL' >> /etc/sudoers
-  export SYNC_USERS_GROUPS="wheel"
-  export SYNC_USERS_GID ="500"
+  SYNC_USERS_GROUPS=wheel
+  SYNC_USERS_GID=500
 
 else
 
   echo '%sudo  ALL=(ALL:ALL) NOPASSWD:ALL' > /etc/sudoers.d/group
-  export SYNC_USERS_GROUPS="sudo"
-  export SYNC_USERS_GID="1000"
+  SYNC_USERS_GROUPS=sudo
+  SYNC_USERS_GID=1000
 
 fi
 
@@ -25,7 +25,7 @@ else
 fi
 
 # Create secret file
-cat << EOF > /etc/defaults/github-authorized-keys
+cat << EOF > /etc/default/github-authorized-keys
 GITHUB_API_TOKEN=${github_api_token}
 GITHUB_ORGANIZATION=${github_organization}
 GITHUB_TEAM=${github_team}
@@ -36,21 +36,21 @@ SYNC_USERS_ROOT=/
 SYNC_USERS_INTERVAL=300
 LISTEN=:301
 INTEGRATE_SSH=true
-LINUX_USER_ADD_TPL=/usr/sbin/useradd --create-home --password '*' --shell {shell} {username}
-LINUX_USER_ADD_WITH_GID_TPL=/usr/sbin/useradd --create-home --password '*' --shell {shell} --group {group} {username}
-LINUX_USER_ADD_TO_GROUP_TPL=/usr/sbin/usermod --append --groups {group} {username}
-LINUX_USER_DEL_TPL=/usr/sbin/userdel {username}
-SSH_RESTART_TPL=$SSH_RESTART_TPL
+LINUX_USER_ADD_TPL="/usr/sbin/useradd --create-home --password '*' --shell {shell} {username}"
+LINUX_USER_ADD_WITH_GID_TPL="/usr/sbin/useradd --create-home --password '*' --shell {shell} --group {group} {username}"
+LINUX_USER_ADD_TO_GROUP_TPL="/usr/sbin/usermod --append --groups {group} {username}"
+LINUX_USER_DEL_TPL="/usr/sbin/userdel {username}"
+SSH_RESTART_TPL="$SSH_RESTART_TPL"
 AUTHORIZED_KEYS_COMMAND_TPL=/usr/bin/authorized-keys
 EOF
 
 if command -v systemctl >/dev/null; then
-  /usr/bin/curl -Lso /etc/systemd/system/github-authorized-keys.service https://raw.githubusercontent.com/cloudposse/github-authorized-keys/master/contrib/github-authorized-keys-non-docker.service
+  /usr/bin/curl -Lso /etc/systemd/system/github-authorized-keys.service https://raw.githubusercontent.com/cloudposse/github-authorized-keys/systemd_init/contrib/github-authorized-keys-non-docker.service
   /usr/bin/systemctl daemon-reload
   /usr/bin/systemctl enable github-authorized-keys.service
   /usr/bin/systemctl start github-authorized-keys.service
 else
-  /usr/bin/curl -Lso /etc/init.d/github-authorized-keys https://raw.githubusercontent.com/cloudposse/github-authorized-keys/master/contrib/github-authorized-keys-rhel.initd
+  /usr/bin/curl -Lso /etc/init.d/github-authorized-keys https://raw.githubusercontent.com/cloudposse/github-authorized-keys/systemd_init/contrib/github-authorized-keys-rhel.initd
   /bin/chmod +x /etc/init.d/github-authorized-keys
   /etc/init.d/github-authorized-keys start
   /sbin/chkconfig github-authorized-keys on

--- a/user_data.sh
+++ b/user_data.sh
@@ -19,9 +19,9 @@ else
 fi
 
 if command -v systemctl >/dev/null; then
-  export SSH_RESTART_TPL="/bin/systemctl restart sshd.service"
+  SSH_RESTART_TPL="/bin/systemctl restart sshd.service"
 else
-  export SSH_RESTART_TPL="/etc/init.d/sshd restart"
+  SSH_RESTART_TPL="/etc/init.d/sshd restart"
 fi
 
 # Create secret file
@@ -31,8 +31,8 @@ cat << EOF > /etc/secrets/github-authorized-keys
 GITHUB_API_TOKEN=${github_api_token}
 GITHUB_ORGANIZATION=${github_organization}
 GITHUB_TEAM=${github_team}
-SYNC_USERS_GID=${SYNC_USERS_GROUPS}
-SYNC_USERS_GROUPS=${SYNC_USERS_GROUPS}
+SYNC_USERS_GID=$SYNC_USERS_GID
+SYNC_USERS_GROUPS=$SYNC_USERS_GROUPS
 SYNC_USERS_SHELL=/bin/bash
 SYNC_USERS_ROOT=/
 SYNC_USERS_INTERVAL=300
@@ -42,7 +42,7 @@ LINUX_USER_ADD_TPL=/usr/sbin/useradd --create-home --password '*' --shell {shell
 LINUX_USER_ADD_WITH_GID_TPL=/usr/sbin/useradd --create-home --password '*' --shell {shell} --group {group} {username}
 LINUX_USER_ADD_TO_GROUP_TPL=/usr/sbin/usermod --append --groups {group} {username}
 LINUX_USER_DEL_TPL=/usr/sbin/userdel {username}
-SSH_RESTART_TPL=${SSH_RESTART_TPL}
+SSH_RESTART_TPL=$SSH_RESTART_TPL
 AUTHORIZED_KEYS_COMMAND_TPL=/usr/bin/authorized-keys
 EOF
 

--- a/user_data.sh
+++ b/user_data.sh
@@ -1,18 +1,38 @@
+#!/bin/bash
 ##
 # Github Authorized Keys Setup
 ##
 
-# Do not require password for users in sudo group 
-echo '%sudo  ALL=(ALL:ALL) NOPASSWD:ALL' > /etc/sudoers.d/group
+# Do not require password for users in sudo group
+if  [ -f "/etc/redhat-release" ]; then
 
-mkdir /etc/secrets
-chmod 700 /etc/secrets
-cat <<"__EOF__" > /etc/secrets/github-authorized-keys
+  echo '%wheel	ALL=(ALL)	NOPASSWD: ALL' >> /etc/sudoers
+  export SYNC_USERS_GROUPS="wheel"
+  export SYNC_USERS_GID ="500"
+
+else
+
+  echo '%sudo  ALL=(ALL:ALL) NOPASSWD:ALL' > /etc/sudoers.d/group
+  export SYNC_USERS_GROUPS="sudo"
+  export SYNC_USERS_GID="1000"
+
+fi
+
+if command -v systemctl >/dev/null; then
+  export SSH_RESTART_TPL="/bin/systemctl restart sshd.service"
+else
+  export SSH_RESTART_TPL="/etc/init.d/sshd restart"
+fi
+
+# Create secret file
+/bin/mkdir /etc/secrets
+/bin/chmod 700 /etc/secrets
+cat << EOF > /etc/secrets/github-authorized-keys
 GITHUB_API_TOKEN=${github_api_token}
 GITHUB_ORGANIZATION=${github_organization}
 GITHUB_TEAM=${github_team}
-SYNC_USERS_GID=500
-SYNC_USERS_GROUPS=sudo
+SYNC_USERS_GID=${SYNC_USERS_GROUPS}
+SYNC_USERS_GROUPS=${SYNC_USERS_GROUPS}
 SYNC_USERS_SHELL=/bin/bash
 SYNC_USERS_ROOT=/
 SYNC_USERS_INTERVAL=300
@@ -22,29 +42,18 @@ LINUX_USER_ADD_TPL=/usr/sbin/useradd --create-home --password '*' --shell {shell
 LINUX_USER_ADD_WITH_GID_TPL=/usr/sbin/useradd --create-home --password '*' --shell {shell} --group {group} {username}
 LINUX_USER_ADD_TO_GROUP_TPL=/usr/sbin/usermod --append --groups {group} {username}
 LINUX_USER_DEL_TPL=/usr/sbin/userdel {username}
-SSH_RESTART_TPL=/bin/systemctl restart sshd.service
+SSH_RESTART_TPL=${SSH_RESTART_TPL}
 AUTHORIZED_KEYS_COMMAND_TPL=/usr/bin/authorized-keys
-__EOF__
+EOF
 
-cat <<"__EOF__" > /etc/systemd/system/github-authorized-keys.service
-[Unit]
-Description=GitHub Authorized Keys
-
-Requires=network-online.target
-After=network-online.target
-
-[Service]
-User=root
-TimeoutStartSec=0
-EnvironmentFile=/etc/secrets/%p
-ExecStartPre=-/usr/bin/curl -Lso /usr/bin/authorized-keys https://raw.githubusercontent.com/cloudposse/github-authorized-keys/master/contrib/authorized-keys
-ExecStartPre=-/bin/chmod 755 /usr/bin/authorized-keys
-ExecStartPre=-/usr/bin/curl -Lso /usr/bin/github-authorized-keys https://github.com/cloudposse/github-authorized-keys/releases/download/1.0.3/github-authorized-keys_linux_amd64
-ExecStartPre=-/bin/chmod 755 /usr/bin/github-authorized-keys
-ExecStart=/usr/bin/github-authorized-keys
-TimeoutStopSec=20s
-Restart=always
-RestartSec=10s
-__EOF__
-systemctl daemon-reload
-systemctl start github-authorized-keys.service
+if command -v systemctl >/dev/null; then
+  /usr/bin/curl -Lso /etc/systemd/system/github-authorized-keys.service https://raw.githubusercontent.com/cloudposse/github-authorized-keys/master/contrib/github-authorized-keys-non-docker.service
+  /usr/bin/systemctl daemon-reload
+  /usr/bin/systemctl enable github-authorized-keys.service
+  /usr/bin/systemctl start github-authorized-keys.service
+else
+  /usr/bin/curl -Lso /etc/init.d/github-authorized-keys https://raw.githubusercontent.com/cloudposse/github-authorized-keys/master/contrib/github-authorized-keys-rhel.initd
+  /bin/chmod +x /etc/init.d/github-authorized-keys
+  /etc/init.d/github-authorized-keys start
+  /sbin/chkconfig github-authorized-keys on
+fi


### PR DESCRIPTION
## What

* Add CentOS support to github-authorized-keys

## Why

* `user_data.sh` works only with `systemd`


