### PR TITLE
Enable `github-authorized-keys` auto start

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -47,4 +47,5 @@ Restart=always
 RestartSec=10s
 __EOF__
 systemctl daemon-reload
+systemctl enable github-authorized-keys.service
 systemctl start github-authorized-keys.service


### PR DESCRIPTION
## What
* Enable `github-authorized-keys` auto start
## Why
* The service should be started after an instance is restarted

## Plan
![image](https://user-images.githubusercontent.com/1134449/31228253-84b6e20a-a9e5-11e7-8fb2-6074ea25a2a5.png)
